### PR TITLE
Fix max log batch size

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	maxBatchByteSize = 1048576
+	maxBatchByteSize = 1048576 - 1024 // Reserve 1KB for request body overhead.
 	maxBatchLength   = 10000
 	logEventOverhead = 26
 )


### PR DESCRIPTION
Reserves 1KB for request body overhead.