### PR TITLE
Set NextSequenceToken on error

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -174,6 +174,9 @@ func (cwl *CloudWatchLogger) sendToCloudWatchLogs(batch logBatch, batchByteSize 
 	txn.End()
 
 	if err != nil {
+		if resp != nil && resp.NextSequenceToken != nil {
+			cwl.sequenceToken = resp.NextSequenceToken
+		}
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() == "ResourceNotFoundException" {
 				if err = cwl.createLogStream(); err != nil {


### PR DESCRIPTION
Documentation isn't very clear on whether some error responses send the next sequence token or not. This shouldn't hurt in any case.